### PR TITLE
Inf 277 vary accept language

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ No modules.
 | <a name="input_static_cache_control"></a> [static\_cache\_control](#input\_static\_cache\_control) | Add cache-control headers for static files | `bool` | `true` | no |
 | <a name="input_tarpit"></a> [tarpit](#input\_tarpit) | Whether to enable tarpit (anti-abuse rate limiting). | `bool` | `true` | no |
 | <a name="input_use_ssl"></a> [use\_ssl](#input\_use\_ssl) | Whether or not to use SSL to reach the Backend. | `bool` | `true` | no |
+| <a name="input_vary_accept_language"></a> [vary\_accept\_language](#input\_vary\_accept\_language) | Whether to set 'Vary: Accept-Language' as a header with language-specific pages | `bool` | `true` | no |
 | <a name="input_vcl_snippets"></a> [vcl\_snippets](#input\_vcl\_snippets) | Additional custom VCL snippets to add to the service. | <pre>list(object({<br>    content  = string<br>    name     = string<br>    type     = string<br>    priority = optional(number, 100)<br>  }))</pre> | `[]` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ locals {
   vcl_tarpit                = file("${path.module}/vcl/tarpit.vcl")
   vcl_globeviz              = templatefile("${path.module}/vcl/globeviz.vcl", { service = var.globeviz_service })
   vcl_purge_auth            = file("${path.module}/vcl/purge_auth.vcl")
+  vcl_vary_accept_language  = file("${path.module}/vcl/language_vary.vcl")
   vcl_media_redirect = templatefile("${path.module}/vcl/media_redirect.vcl", {
     backend  = "F_${replace(local.media_backend_name, " ", "_")}",
     redirect = var.media_backend["bucket_prefix"]
@@ -322,6 +323,17 @@ resource "fastly_service_vcl" "app_service" {
     for_each = var.purge_auth ? [1] : []
     content {
       name     = "Purge Authentication Header"
+      content  = local.vcl_purge_auth
+      type     = "recv"
+      priority = 100
+    }
+  }
+
+  # Vary: Accept-Language header additions
+  dynamic "snippet" {
+    for_each = var.vary_accept_language ? [1] : []
+    content {
+      name     = "Vary Accept-Language"
       content  = local.vcl_purge_auth
       type     = "recv"
       priority = 100

--- a/main.tf
+++ b/main.tf
@@ -334,7 +334,7 @@ resource "fastly_service_vcl" "app_service" {
     for_each = var.vary_accept_language ? [1] : []
     content {
       name     = "Vary Accept-Language"
-      content  = local.vcl_purge_auth
+      content  = local.vcl_vary_accept_language
       type     = "recv"
       priority = 100
     }

--- a/variables.tf
+++ b/variables.tf
@@ -224,6 +224,12 @@ variable "apple_associated_domain" {
   default     = true
 }
 
+variable "vary_accept_language" {
+  description = "Whether to set 'Vary: Accept-Language' as a header with language-specific pages"
+  type        = bool
+  default     = true
+}
+
 variable "vcl_snippets" {
   description = "Additional custom VCL snippets to add to the service."
   type = list(object({

--- a/vcl/language_vary.vcl
+++ b/vcl/language_vary.vcl
@@ -1,0 +1,3 @@
+if ( req.url.path ~ "^/[a-zA-Z]{2}(?:-[a-zA-Z]{2})?/" ) {
+  req.http.Vary = "Accept-Language";
+}


### PR DESCRIPTION
This adds the header `Vary: Accept-Language` to any incoming request that has a language-specific page.

It checks this by looking for a URL that starts with either `/xx/` or `/xx-xx/` where `x` is any lower- or upper-case letter.